### PR TITLE
Fixing bugs in header on Safari

### DIFF
--- a/development-guide.md
+++ b/development-guide.md
@@ -118,6 +118,8 @@ Once, the documentation is made/updated, run `npm run build`, and the documentat
 The University of Guelph Web Components Library is hosted as a npm package, making it simpler for development teams to use it. As a result when changes are made, the package must be republished to npm, here's how to do that:
 
 1. You must have a npm account with organization access to [https://www.npmjs.com/package/@uoguelph/web-components](https://www.npmjs.com/package/@uoguelph/web-components).
-2. You must update the package version using the command `npm version NEW_VERSION_NUMBER_HERE`. Note the version number must follow the semantic version guidelines outlined [here](https://docs.npmjs.com/about-semantic-versioning)
-3. Do a final check, make sure the changes made haven't broken anything, ensure all the components have documentation, etc.
+2. Do a final check, make sure the changes made haven't broken anything, ensure all the components have documentation, etc.
+3. You must update the package version using the command `npm version NEW_VERSION_NUMBER_HERE`. Note the version number must follow the semantic version guidelines outlined [here](https://docs.npmjs.com/about-semantic-versioning) or instead of specifying the version your self use one of the following `major | minor | patch | premajor | preminor | prepatch` (NOTE: `premajor | preminor | prepatch` must be following with `--preid rc` )
 4. Finally, publish the package using the command `npm publish `.
+
+It's important to always test the package on other environments

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.1.4",
+  "version": "1.2.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.1.4",
+      "version": "1.2.0-rc.0",
       "license": "0BSD",
       "dependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.1.4",
+  "version": "1.2.0-rc.0",
   "description": "University of Guelph Web Components Library",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/uofg-header/uofg-header.tsx
+++ b/src/components/uofg-header/uofg-header.tsx
@@ -270,7 +270,10 @@ export class UofgHeader {
           {/* Logo */}
           <div class="tw-flex">
             {this.isFullSize && (
-              <div class="tw-left-0 tw-h-full min-[1320px]:tw-absolute [&>svg]:tw-h-full" innerHTML={Decoration}></div>
+              <div
+                class="tw-left-0 tw-h-full tw-w-[7.5rem] min-[1320px]:tw-absolute [&>svg]:tw-h-full"
+                innerHTML={Decoration}
+              ></div>
             )}
 
             <a
@@ -319,7 +322,7 @@ export class UofgHeader {
               ))}
 
               {/* Main menu */}
-              <uofg-menu auto-collapse={true}>
+              <uofg-menu class="tw-block tw-h-full" auto-collapse={true}>
                 <button
                   slot="button"
                   aria-label="Main Menu"
@@ -329,7 +332,7 @@ export class UofgHeader {
                 </button>
                 <div
                   slot="content"
-                  class="tw-absolute tw-left-0 tw-top-full tw-z-50 tw-flex tw-w-full tw-flex-col tw-bg-white tw-p-4 tw-text-black tw-shadow-sm"
+                  class="tw-absolute tw-left-0 tw-top-full tw-z-50 tw-flex tw-w-full tw-flex-col tw-bg-white tw-px-4 tw-text-black tw-shadow-sm"
                 >
                   <span class="tw-my-4 tw-text-4xl tw-font-bold">University of Guelph</span>
 
@@ -347,7 +350,7 @@ export class UofgHeader {
                   </ul>
 
                   {/* Resources menu */}
-                  <uofg-menu class="tw-relative tw-block tw-h-full tw-text-black" auto-collapse={false}>
+                  <uofg-menu class="tw-relative tw-block tw-h-full tw-pb-4 tw-text-black" auto-collapse={false}>
                     <button
                       class="tw-flex tw-h-auto tw-w-full tw-items-center tw-justify-between tw-border-0 tw-border-b tw-border-solid tw-border-uofg-grey-400 tw-p-5 tw-transition-colors hover:tw-bg-uofg-grey aria-expanded:tw-bg-uofg-grey [&>svg]:tw-h-[1em] [&>svg]:tw-fill-current [&>svg]:tw-transition-transform [&>svg]:aria-expanded:tw-rotate-180"
                       slot="button"
@@ -448,7 +451,7 @@ export class UofgHeader {
                 })}
               </ul>
             ) : (
-              <uofg-menu class="lg:tw-relative" auto-collapse={true}>
+              <uofg-menu class="tw-block tw-h-full lg:tw-relative" auto-collapse={true}>
                 <button
                   class="tw-flex tw-aspect-square tw-h-full tw-items-center tw-justify-center tw-border-0 tw-border-l tw-border-solid tw-border-uofg-grey-300 tw-px-6 tw-transition-colors aria-expanded:tw-bg-uofg-yellow lg:tw-border-l-0 [&>svg]:tw-h-[1em] [&>svg]:tw-fill-current"
                   slot="button"
@@ -457,7 +460,7 @@ export class UofgHeader {
                   <FontAwesomeIcon icon={faBars} />
                 </button>
                 <ul
-                  class="tw-absolute tw-right-0 tw-top-full tw-z-50 tw-flex tw-w-full tw-flex-col tw-bg-white tw-p-4 tw-text-black tw-shadow-sm lg:tw-w-[30rem] [&>li]:tw-contents"
+                  class="tw-absolute tw-right-0 tw-top-full tw-z-50 tw-flex tw-w-full tw-flex-col tw-bg-white tw-px-4 tw-text-black tw-shadow-sm lg:tw-w-[30rem] [&>li]:tw-contents"
                   slot="content"
                 >
                   {this.pageSpecificContent?.map(item => {

--- a/src/components/uofg-header/uofg-header.tsx
+++ b/src/components/uofg-header/uofg-header.tsx
@@ -332,7 +332,7 @@ export class UofgHeader {
                 </button>
                 <div
                   slot="content"
-                  class="tw-absolute tw-left-0 tw-top-full tw-z-50 tw-flex tw-w-full tw-flex-col tw-bg-white tw-px-4 tw-text-black tw-shadow-sm"
+                  class="tw-absolute tw-left-0 tw-top-full tw-z-50 tw-flex tw-w-full tw-flex-col tw-bg-white tw-px-4 tw-text-black tw-shadow-md"
                 >
                   <span class="tw-my-4 tw-text-4xl tw-font-bold">University of Guelph</span>
 
@@ -350,7 +350,7 @@ export class UofgHeader {
                   </ul>
 
                   {/* Resources menu */}
-                  <uofg-menu class="tw-relative tw-block tw-h-full tw-pb-4 tw-text-black" auto-collapse={false}>
+                  <uofg-menu class="tw-relative tw-block tw-h-full tw-pb-6 tw-text-black" auto-collapse={false}>
                     <button
                       class="tw-flex tw-h-auto tw-w-full tw-items-center tw-justify-between tw-border-0 tw-border-b tw-border-solid tw-border-uofg-grey-400 tw-p-5 tw-transition-colors hover:tw-bg-uofg-grey aria-expanded:tw-bg-uofg-grey [&>svg]:tw-h-[1em] [&>svg]:tw-fill-current [&>svg]:tw-transition-transform [&>svg]:aria-expanded:tw-rotate-180"
                       slot="button"
@@ -460,13 +460,13 @@ export class UofgHeader {
                   <FontAwesomeIcon icon={faBars} />
                 </button>
                 <ul
-                  class="tw-absolute tw-right-0 tw-top-full tw-z-50 tw-flex tw-w-full tw-flex-col tw-bg-white tw-px-4 tw-text-black tw-shadow-sm lg:tw-w-[30rem] [&>li]:tw-contents"
+                  class="tw-absolute tw-right-0 tw-top-full tw-z-50 tw-flex tw-w-full tw-flex-col tw-bg-white tw-px-4 tw-text-black tw-shadow-md lg:tw-w-[30rem] [&>li]:tw-contents"
                   slot="content"
                 >
                   {this.pageSpecificContent?.map(item => {
                     if ('text' in item) {
                       return (
-                        <li>
+                        <li class="[&>a]:last:tw-pb-4">
                           <a
                             href={item.href}
                             class="tw-w-full tw-border-0 tw-border-b tw-border-solid tw-border-uofg-grey-400 tw-p-5 tw-transition-colors hover:tw-bg-uofg-grey"
@@ -478,7 +478,7 @@ export class UofgHeader {
                     }
 
                     return (
-                      <li>
+                      <li class="[&>uofg-menu]:last:tw-pb-6">
                         <uofg-menu class="tw-relative tw-block tw-h-full tw-text-black" auto-collapse={false}>
                           <button
                             class="tw-flex tw-h-auto tw-w-full tw-items-center tw-justify-between tw-border-0 tw-border-b tw-border-solid tw-border-uofg-grey-400 tw-p-5 tw-transition-colors hover:tw-bg-uofg-grey aria-expanded:tw-bg-uofg-grey [&>svg]:tw-h-[1em] [&>svg]:tw-fill-current [&>svg]:tw-transition-transform [&>svg]:aria-expanded:tw-rotate-180"


### PR DESCRIPTION
Fixes two bugs in the header that occur on safari.

1. The red and yellow svg overlapping with the logo on smaller screens.
2. The menu buttons on mobile causing a horizontal overflow.