### PR TITLE
Add conditional for rendering subFooter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.2.2-rc.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.2.2-rc.0",
+      "version": "1.2.1",
       "license": "0BSD",
       "dependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.2.2-rc.0",
+  "version": "1.2.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.2.2-rc.0",
+      "version": "1.2.2-rc.1",
       "license": "0BSD",
       "dependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.2.1",
+  "version": "1.2.2-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.2.1",
+      "version": "1.2.2-rc.0",
       "license": "0BSD",
       "dependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.2.2-rc.0",
+  "version": "1.2.1",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.2.2-rc.0",
+  "version": "1.2.2-rc.1",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.2.1",
+  "version": "1.2.2-rc.0",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/src/components/uofg-footer.svelte
+++ b/src/components/uofg-footer.svelte
@@ -158,7 +158,7 @@
 </script>
 
 <footer>
-  {#if Array.isArray(subFooter)}
+  {#if Array.isArray(subFooter) && subFooter.length > 0}
     <ul
       class="flex flex-wrap items-center justify-center bg-uofg-blue-50 p-6 px-[max(calc((100%-1320px)/2),2rem)]"
     >


### PR DESCRIPTION
Siteimprove is reporting a Level A issue associated with the footer, due to an empty ul element being rendered. I've added a conditional to check if there are more than 0 elements in the array before rendering the ul element.

<img width="1517" alt="image" src="https://github.com/ccswbs/web-components/assets/1927902/440057be-3213-49bf-b31e-ca615dc61c5c">

# Testing Methodology

1. Clone the repo
2. Run `npm install`
3. Run `npm run dev`
4. Notice that there is a blue bar with a bunch of Example Menu Links.
5. While running the environment, change the index.html file so there are no children items available in `<uofg-footer>`.

Change this...
```
      <uofg-footer>
        <a href="#">Example Menu Link</a>
        <a href="#">Example Menu Link 1</a>
        <a href="#">Example Menu Link 2</a>
        <a href="#">Example Menu Link 3</a>
        <a href="#">Example Menu Link 4</a>
        <a href="#">Example Menu Link 5</a>
        <a href="#">Example Menu Link 6</a>
      </uofg-footer>
```

To this...
```
      <uofg-footer>
      </uofg-footer>
```

6. Save index.html.
7. Refresh your dev environment
8. The blue bar should no longer be showing and there should no longer be an empty list.