### PR TITLE
Bug fix: Header sub menu links can have their styles overwritten

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.2.1",
+  "version": "1.2.2-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.2.1",
+      "version": "1.2.2-rc.2",
       "license": "0BSD",
       "dependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.2.1",
+  "version": "1.2.2-rc.2",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/src/components/uofg-header.svelte
+++ b/src/components/uofg-header.svelte
@@ -510,9 +510,9 @@
                     {#each item.links as link}
                       <li>
                         <a
-                          class="border-0 border-b border-solid border-uofg-grey-500 p-4 transition-colors hover:bg-uofg-grey"
-                          href={link.href}
                           {...link.attributes}
+                          class={`border-0 border-b border-solid border-uofg-grey-500 p-4 transition-colors hover:bg-uofg-grey ${link.attributes?.class ?? ""}`}
+                          href={link.href}
                         >
                           {link.text}
                         </a>

--- a/src/components/uofg-header.svelte
+++ b/src/components/uofg-header.svelte
@@ -437,9 +437,9 @@
                 <!-- Link -->
 
                 <a
-                  class="flex h-full items-center justify-center gap-2 px-4 transition-colors hover:bg-uofg-yellow"
-                  href={item.href}
                   {...item.attributes}
+                  class={`flex h-full items-center justify-center gap-2 px-4 transition-colors hover:bg-uofg-yellow ${item.attributes?.class ?? ""}`}
+                  href={item.href}
                 >
                   {item.text}
                 </a>
@@ -460,9 +460,9 @@
                   {#each item.links as link}
                     <li>
                       <a
-                        class="border-0 border-b border-solid border-uofg-grey-500 p-4 transition-colors hover:bg-uofg-yellow"
-                        href={link.href}
                         {...link.attributes}
+                        class={`border-0 border-b border-solid border-uofg-grey-500 p-4 transition-colors hover:bg-uofg-yellow ${link.attributes?.class ?? ""}`}
+                        href={link.href}
                       >
                         {link.text}
                       </a>
@@ -487,9 +487,9 @@
                 {#if item.text}
                   <!-- Link -->
                   <a
-                    class="border-0 border-b border-solid border-uofg-grey-500 p-4 transition-colors hover:bg-uofg-grey"
-                    href={item.href}
                     {...item.attributes}
+                    class={`border-0 border-b border-solid border-uofg-grey-500 p-4 transition-colors hover:bg-uofg-grey ${item.attributes?.class ?? ""}`}
+                    href={item.href}
                   >
                     {item.text}
                   </a>


### PR DESCRIPTION
When sub menu links have their own class tag ex.

```html
<uofg-header>
  <a href="#" class="somerandomclass">Example Link</a>
</uofg-header>
```

That class will overwrite the tailwind classes that are used to style that a tag.

Solution: merge the classes together.

Go to https://universi18t2.valhalla47.stage.jobs2web.com/ and open the Careers Login menu for an example of the bug.