### PR TITLE
Changing style for links above footer.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.4.2-rc.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.4.2-rc.0",
+      "version": "1.4.2",
       "license": "0BSD",
       "devDependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.4.1",
+  "version": "1.4.2-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.4.1",
+      "version": "1.4.2-rc.0",
       "license": "0BSD",
       "devDependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.4.1",
+  "version": "1.4.2-rc.0",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.4.2-rc.0",
+  "version": "1.4.2",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/src/components/uofg-footer.svelte
+++ b/src/components/uofg-footer.svelte
@@ -159,10 +159,13 @@
 
 <footer>
   {#if Array.isArray(subFooter) && subFooter.length > 0}
-    <ul class="flex flex-wrap items-center justify-center bg-uofg-blue-50 p-6 px-[max(calc((100%-1320px)/2),2rem)]">
+    <ul class="flex flex-wrap items-center justify-center bg-white p-6 px-[max(calc((100%-1320px)/2),2rem)]">
       {#each subFooter as { text, href }}
-        <li class="border-0 border-r-2 border-solid border-uofg-blue-100 p-2 first:border-l-2">
-          <a class="text-uofg-blue-500 transition-colors hover:text-uofg-blue-950 focus:text-uofg-blue-950" {href}>
+        <li class="p-6">
+          <a
+            class="transition-all decoration-transparent text-[#2e74bb] hover:text-[#1a4168] focus:text-[#1a4168] hover:underline focus:underline hover:decoration-current focus:decoration-current"
+            {href}
+          >
             {text}
           </a>
         </li>


### PR DESCRIPTION
Updating the style for the links that appear above the footer

From this:
<img width="1086" alt="4bb0d715-3819-4c2e-abd0-ffe98791bac6" src="https://github.com/user-attachments/assets/c18fe9f0-824c-4db1-bb17-1cb2e5434e30">

To this:
![footer-links](https://github.com/user-attachments/assets/34eba7ca-e842-433c-b172-38e9f113cabb)

Currently this feature is only used on the HRMS site, so to test you need to use Requestly as I described in this Tango: https://app.tango.us/app/workflow/Using-Requestly-to-Test--uoguelph-web-components-06b2ee0c63c0416d8c31080a767222ef (If you have another means of redirecting network requests, feel free to use that)

You can also test locally.
