### PR TITLE
Accessibility fix for back-to-top button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "0BSD",
       "devDependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/src/components/uofg-back-to-top.svelte
+++ b/src/components/uofg-back-to-top.svelte
@@ -35,6 +35,7 @@
 <svelte:window bind:scrollY />
 
 <button
+  aria-label="Scroll to top"
   on:click={scrollToTop}
   class={twJoin(
     'flex z-10 justify-center items-center text-4xl w-16 h-16 border border-white bg-black fixed bottom-8 right-8 text-white hover:bg-uofg-red focus:bg-uofg-red transition',

--- a/src/components/uofg-back-to-top.svelte
+++ b/src/components/uofg-back-to-top.svelte
@@ -35,12 +35,14 @@
 <svelte:window bind:scrollY />
 
 <button
-  aria-label="Scroll to top"
   on:click={scrollToTop}
   class={twJoin(
     'flex z-10 justify-center items-center text-4xl w-16 h-16 border border-white bg-black fixed bottom-8 right-8 text-white hover:bg-uofg-red focus:bg-uofg-red transition',
     visible ? 'opacity-100' : 'opacity-0',
   )}
 >
-  <FontAwesomeIcon icon={faChevronUp} />
+  <span aria-hidden="true">
+    <FontAwesomeIcon icon={faChevronUp} />
+  </span>
+  <span class="sr-only">Back to top of page</span>
 </button>


### PR DESCRIPTION
Fix accessibility issue with `Back to Top` button by adding an `aria-label` attribute for screenreaders.