### PR TITLE
Link Academics to Program Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.2-rc.0",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.7.2-rc.0",
+      "version": "1.7.2",
       "license": "0BSD",
       "dependencies": {
         "tailwind-join": "^0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.1",
+  "version": "1.7.2-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.7.1",
+      "version": "1.7.2-rc.0",
       "license": "0BSD",
       "dependencies": {
         "tailwind-join": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.2-rc.0",
+  "version": "1.7.2",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.1",
+  "version": "1.7.2-rc.0",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/src/components/uofg-header/data/guelph.js
+++ b/src/components/uofg-header/data/guelph.js
@@ -7,7 +7,7 @@ export const primaryLinks = [
   },
   {
     text: 'Academics',
-    href: 'https://www.uoguelph.ca/explore-all-programs/',
+    href: 'https://www.uoguelph.ca/programs/undergraduate',
   },
   {
     text: 'Admission',


### PR DESCRIPTION
Update Academics link to navigate to Program Search (instead of Explore All Programs).

This will be released _after_ the Program Search is live. (There will be a gateway redirect from explore-all-programs to the new page, so users will still reach the correct page during the window of time when this has not been released yet.)

Test Plan:

- Confirm the Academics link goes to https://www.uoguelph.ca/programs/undergraduate