### PR TITLE
Fix undefined showing in sub navigation in uofg-header

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,21 +15,9 @@
         margin: 0;
         padding: 0;
       }
-
-      #app {
-        display: flex;
-        flex-direction: column;
-        height: 130vh;
-      }
-
-      main {
-        flex: 1;
-      }
     </style>
   </head>
   <body>
-    <div id="app">
-      <!-- TEST CODE HERE -->
-    </div>
+    <!-- TEST CODE HERE -->
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Svelte</title>
-
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap" rel="stylesheet" />
@@ -26,58 +25,11 @@
       main {
         flex: 1;
       }
-
-      uofg-header * {
-        display: none;
-      }
-
-      uofg-footer * {
-        display: none;
-      }
     </style>
   </head>
   <body>
     <div id="app">
-      <uofg-header page-title="Example Department" page-url="#">
-        <a href="#">Example Menu Link</a>
-        <a href="#">Example Menu Link 2</a>
-
-        <ul data-title="Example Menu">
-          <li><a href="#">Example Menu Link 1</a></li>
-          <li><a href="#">This is a really long Example Menu Link 2</a></li>
-          <li><a href="#">Example Menu Link 3</a></li>
-        </ul>
-      </uofg-header>
-
-      <main>
-        <button id="modal-btn">Open Modal</button>
-        <uofg-modal label="Alert Modal" static-backdrop alert-dialog>
-          <uofg-alert>
-            <span slot="title">YOUR TITLE HERE</span>
-            <span slot="subtitle">YOUR SUBTITLE HERE</span>
-            <span slot="message">YOUR ALERT MESSAGE HERE</span>
-            <span slot="footer">YOUR FOOTER CONTENT HERE</span>
-          </uofg-alert>
-        </uofg-modal>
-      </main>
-
-      <uofg-footer>
-        <a href="#">Example Menu Link</a>
-        <a href="#">Example Menu Link 1</a>
-        <a href="#">Example Menu Link 2</a>
-        <a href="#">Example Menu Link 3</a>
-        <a href="#">Example Menu Link 4</a>
-        <a href="#">Example Menu Link 5</a>
-        <a href="#">Example Menu Link 6</a>
-      </uofg-footer>
-
-      <uofg-back-to-top></uofg-back-to-top>
+      <!-- TEST CODE HERE -->
     </div>
-
-    <script>
-      document.getElementById('modal-btn').addEventListener('click', () => {
-        document.querySelector('uofg-modal').open();
-      });
-    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Svelte</title>
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap" rel="stylesheet" />
@@ -15,9 +16,68 @@
         margin: 0;
         padding: 0;
       }
+
+      #app {
+        display: flex;
+        flex-direction: column;
+        height: 130vh;
+      }
+
+      main {
+        flex: 1;
+      }
+
+      uofg-header * {
+        display: none;
+      }
+
+      uofg-footer * {
+        display: none;
+      }
     </style>
   </head>
   <body>
-    <!-- TEST CODE HERE -->
+    <div id="app">
+      <uofg-header page-title="Example Department" page-url="#">
+        <a href="#">Example Menu Link</a>
+        <a href="#">Example Menu Link 2</a>
+
+        <ul data-title="Example Menu">
+          <li><a href="#">Example Menu Link 1</a></li>
+          <li><a href="#">This is a really long Example Menu Link 2</a></li>
+          <li><a href="#">Example Menu Link 3</a></li>
+        </ul>
+      </uofg-header>
+
+      <main>
+        <button id="modal-btn">Open Modal</button>
+        <uofg-modal label="Alert Modal" static-backdrop alert-dialog>
+          <uofg-alert>
+            <span slot="title">YOUR TITLE HERE</span>
+            <span slot="subtitle">YOUR SUBTITLE HERE</span>
+            <span slot="message">YOUR ALERT MESSAGE HERE</span>
+            <span slot="footer">YOUR FOOTER CONTENT HERE</span>
+          </uofg-alert>
+        </uofg-modal>
+      </main>
+
+      <uofg-footer>
+        <a href="#">Example Menu Link</a>
+        <a href="#">Example Menu Link 1</a>
+        <a href="#">Example Menu Link 2</a>
+        <a href="#">Example Menu Link 3</a>
+        <a href="#">Example Menu Link 4</a>
+        <a href="#">Example Menu Link 5</a>
+        <a href="#">Example Menu Link 6</a>
+      </uofg-footer>
+
+      <uofg-back-to-top></uofg-back-to-top>
+    </div>
+
+    <script>
+      document.getElementById('modal-btn').addEventListener('click', () => {
+        document.querySelector('uofg-modal').open();
+      });
+    </script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3-rc.0",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.7.3-rc.0",
+      "version": "1.7.3",
       "license": "0BSD",
       "dependencies": {
         "tailwind-join": "^0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3",
+  "version": "1.7.3-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.7.3",
+      "version": "1.7.3-rc.1",
       "license": "0BSD",
       "dependencies": {
         "tailwind-join": "^0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3-rc.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.7.3-rc.2",
+      "version": "1.7.3",
       "license": "0BSD",
       "dependencies": {
         "tailwind-join": "^0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3-rc.1",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.7.3-rc.1",
+      "version": "1.7.3",
       "license": "0BSD",
       "dependencies": {
         "tailwind-join": "^0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3",
+  "version": "1.7.3-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.7.3",
+      "version": "1.7.3-rc.2",
       "license": "0BSD",
       "dependencies": {
         "tailwind-join": "^0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.2",
+  "version": "1.7.3-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/web-components",
-      "version": "1.7.2",
+      "version": "1.7.3-rc.0",
       "license": "0BSD",
       "dependencies": {
         "tailwind-join": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dev": "vite",
     "build": "vite build",
     "format": "npx prettier --write .",
-    "prepublishOnly": "npm run build && npmignore --auto"
+    "prepublishOnly": "npm run build && npmignore --auto",
+    "track-test-page": "git update-index --no-skip-worktree index.html",
+    "untrack-test-page": "git update-index --skip-worktree index.html"
   },
   "devDependencies": {
     "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3-rc.1",
+  "version": "1.7.3",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3",
+  "version": "1.7.3-rc.1",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3",
+  "version": "1.7.3-rc.2",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "dev": "vite",
     "build": "vite build",
     "format": "npx prettier --write .",
-    "prepublishOnly": "npm run build && npmignore --auto",
-    "track-test-page": "git update-index --no-skip-worktree index.html",
-    "untrack-test-page": "git update-index --skip-worktree index.html"
+    "prepublishOnly": "npm run build && npmignore --auto"
   },
   "devDependencies": {
     "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3-rc.2",
+  "version": "1.7.3",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.2",
+  "version": "1.7.3-rc.0",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "1.7.3-rc.0",
+  "version": "1.7.3",
   "description": "University of Guelph Web Components Library",
   "module": "dist/uofg-web-components/uofg-web-components.esm.js",
   "type": "module",

--- a/src/components/uofg-header/sub-navigation/sub-navigation.svelte
+++ b/src/components/uofg-header/sub-navigation/sub-navigation.svelte
@@ -41,7 +41,7 @@
   bind:clientWidth={containerWidth}
 >
   <div class="flex h-full w-fit min-w-full overflow-y-visible items-center justify-end [&>li]:contents relative">
-    {#if url}
+    {#if title && url}
       <a
         class="mr-auto flex h-full items-center justify-center px-4 font-bold transition-colors hover:bg-uofg-yellow"
         href={url}
@@ -49,7 +49,7 @@
       >
         {title}
       </a>
-    {:else}
+    {:else if title}
       <span bind:clientWidth={titleWidth} class="mr-auto flex h-full items-center justify-center px-4 font-bold">
         {title}
       </span>


### PR DESCRIPTION
Currently some pages show "undefined" where the page/department name appears in the sub navigation.

This occurs when the header is passed a menu, but doesn't have page-title set.

I've fixed the issue by adding a check to only render the element when page-title is set.

Test Plan:
- Go to https://www.uoguelph.ca/cpa/ and see that undefined appears.
- Redirect the package requests to v1.7.3-rc.1 using whatever method use desire (Safari Web Tools, Requestly, or any other redirect tool/extension).
- Go back to https://www.uoguelph.ca/cpa/ and the undefined should be gone